### PR TITLE
feat: add `ci` commit type

### DIFF
--- a/cliff-template.toml
+++ b/cliff-template.toml
@@ -84,10 +84,9 @@ commit_parsers = [
     { message = "(?i)^update", group = "<!-- 26 -->🔄 Update"},
     { message = "(?i)^pin", group = "<!-- 27 -->📌 Pin"},
     { message = "(?i)^unpin", group = "<!-- 28 -->📍 Unpin"},
-    { message = "(?i)^build", group = "<!-- 29 -->👷 CI/CD"},
-    { message = "(?i)^ci", group = "<!-- 30 -->👷 CI/CD"},
-    { message = ".*", group = "<!-- 31 -->📝 Other"},
-    { message = "(?i)^merge", group = "<!-- 32 -->🔀 Merges"},
+    { message = "(?i)^build|ci", group = "<!-- 29 -->👷 CI/CD"},
+    { message = ".*", group = "<!-- 30 -->📝 Other"},
+    { message = "(?i)^merge", group = "<!-- 31 -->🔀 Merges"},
 ]
 tag_pattern = "v[0-9]*"
 topo_order = false

--- a/cliff-template.toml
+++ b/cliff-template.toml
@@ -85,8 +85,9 @@ commit_parsers = [
     { message = "(?i)^pin", group = "<!-- 27 -->📌 Pin"},
     { message = "(?i)^unpin", group = "<!-- 28 -->📍 Unpin"},
     { message = "(?i)^build", group = "<!-- 29 -->👷 CI/CD"},
-    { message = ".*", group = "<!-- 30 -->📝 Other"},
-    { message = "(?i)^merge", group = "<!-- 31 -->🔀 Merges"},
+    { message = "(?i)^ci", group = "<!-- 30 -->👷 CI/CD"},
+    { message = ".*", group = "<!-- 31 -->📝 Other"},
+    { message = "(?i)^merge", group = "<!-- 32 -->🔀 Merges"},
 ]
 tag_pattern = "v[0-9]*"
 topo_order = false


### PR DESCRIPTION
We're using `ci` prefix for some of our CI / CD commits, so this should be grouped to the corresponding section